### PR TITLE
ApacheCloudStackClient: Remove assumed client API url suffixes

### DIFF
--- a/src/main/java/br/com/autonomiccs/apacheCloudStack/client/ApacheCloudStackClient.java
+++ b/src/main/java/br/com/autonomiccs/apacheCloudStack/client/ApacheCloudStackClient.java
@@ -86,15 +86,6 @@ import br.com.autonomiccs.apacheCloudStack.exceptions.ApacheCloudStackClientRunt
  */
 public class ApacheCloudStackClient {
     /**
-     * The suffix 'client' that is the endpoint to access Apache CloudStack.
-     */
-    private final static String CLOUDSTACK_BASE_ENDPOINT_URL_SUFFIX = "client";
-    /**
-     * The Apache CloudStack API endpoint
-     */
-    private static final String APACHE_CLOUDSTACK_API_ENDPOINT = "/api";
-
-    /**
      * This flag indicates if we are going to validate the server certificate in case of HTTPS connections.
      * The default value is 'true', meaning that we always validate the server HTTPS certificate.
      */
@@ -116,8 +107,8 @@ public class ApacheCloudStackClient {
     private Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
-     * The URL used to access Apache CloudStack API.
-     * Ex: https://cloud.domain.com/client
+     * The API URL used to access Apache CloudStack API.
+     * Ex: https://cloud.domain.com/client/api
      */
     private String url;
 
@@ -128,31 +119,9 @@ public class ApacheCloudStackClient {
     protected ApacheCloudStackUser apacheCloudStackUser;
 
     public ApacheCloudStackClient(String url, ApacheCloudStackUser apacheCloudStackUser) {
-        this.url = adjustUrlIfNeeded(url);
+        this.url = url;
         this.apacheCloudStackUser = apacheCloudStackUser;
 
-    }
-
-    /**
-     * adds the suffix '{@value #CLOUDSTACK_BASE_ENDPOINT_URL_SUFFIX}' if it does have it.
-     * It uses the method {@link #appendUrlSuffix(String)} to execute the appending.
-     */
-    protected String adjustUrlIfNeeded(String url) {
-        if (StringUtils.endsWith(url, "/client") || StringUtils.endsWith(url, "/client/")) {
-            return url;
-        }
-        return appendUrlSuffix(url);
-    }
-
-    /**
-     * Appends the suffix '{@value #CLOUDSTACK_BASE_ENDPOINT_URL_SUFFIX}' at the end of the given URL.
-     * If it is needed, it will also add, a '/' before the suffix is appended to the URL.
-     */
-    protected String appendUrlSuffix(String url) {
-        if (StringUtils.endsWith(url, "/")) {
-            return url + CLOUDSTACK_BASE_ENDPOINT_URL_SUFFIX;
-        }
-        return url + "/" + CLOUDSTACK_BASE_ENDPOINT_URL_SUFFIX;
     }
 
     /**
@@ -321,7 +290,7 @@ public class ApacheCloudStackClient {
      *  The content type configured for this request is 'application/x-www-form-urlencoded'.
      */
     protected HttpPost createHttpPost() {
-        HttpPost httpPost = new HttpPost(url + APACHE_CLOUDSTACK_API_ENDPOINT);
+        HttpPost httpPost = new HttpPost(url);
         httpPost.addHeader("Content-Type", "application/x-www-form-urlencoded");
         return httpPost;
     }
@@ -371,15 +340,14 @@ public class ApacheCloudStackClient {
      * and then, if it needs, it creates the signature using the method {@link #createSignature(String)} and append it to the URL.
      */
     protected String createApacheCloudStackApiUrlRequest(ApacheCloudStackRequest request, boolean shouldSignAppendSignature) {
-        StringBuilder urlRequest = new StringBuilder(url + APACHE_CLOUDSTACK_API_ENDPOINT);
-        urlRequest.append("?");
+        StringBuilder urlRequest = new StringBuilder(url).append("?");
 
         String queryString = createCommandString(request);
         urlRequest.append(queryString);
 
         if (shouldSignAppendSignature) {
             String signature = createSignature(queryString);
-            urlRequest.append("&signature=" + getUrlEncodedValue(signature));
+            urlRequest.append("&signature=").append(getUrlEncodedValue(signature));
         }
         return urlRequest.toString();
     }

--- a/src/test/java/br/com/autonomiccs/apacheCloudStack/client/ApacheCloudStackClientTest.java
+++ b/src/test/java/br/com/autonomiccs/apacheCloudStack/client/ApacheCloudStackClientTest.java
@@ -21,17 +21,9 @@
  */
 package br.com.autonomiccs.apacheCloudStack.client;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import br.com.autonomiccs.apacheCloudStack.client.beans.ApacheCloudStackUser;
+import br.com.autonomiccs.apacheCloudStack.exceptions.ApacheCloudStackClientRequestRuntimeException;
+import br.com.autonomiccs.apacheCloudStack.exceptions.ApacheCloudStackClientRuntimeException;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
@@ -61,9 +53,16 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import br.com.autonomiccs.apacheCloudStack.client.beans.ApacheCloudStackUser;
-import br.com.autonomiccs.apacheCloudStack.exceptions.ApacheCloudStackClientRequestRuntimeException;
-import br.com.autonomiccs.apacheCloudStack.exceptions.ApacheCloudStackClientRuntimeException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ApacheCloudStackClientTest {
@@ -74,64 +73,11 @@ public class ApacheCloudStackClientTest {
     private ApacheCloudStackUser apacheCloudStackUser;
 
     private String cloudStackDomain = "cloud.domain.com";
-    private String cloudStackUrl = "https://" + cloudStackDomain + "/client";
+    private String cloudStackUrl = "https://" + cloudStackDomain + "/client/api";
 
     @Before
     public void setup() {
         apacheCloudStackClient = Mockito.spy(new ApacheCloudStackClient(cloudStackUrl, apacheCloudStackUser));
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestEndingWithSuffix() {
-        executeAndVerifyAdjustUrlIfNeededTest(cloudStackUrl, 0);
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestEndingWithoutSuffix() {
-        executeAndVerifyAdjustUrlIfNeededTest("https://cloud.domain.com", 1);
-    }
-
-    private void executeAndVerifyAdjustUrlIfNeededTest(String givenCloudStackUrl, int appendCallTimes) {
-        String url = apacheCloudStackClient.adjustUrlIfNeeded(givenCloudStackUrl);
-
-        Assert.assertEquals(cloudStackUrl, url);
-        Mockito.verify(apacheCloudStackClient, Mockito.times(appendCallTimes)).appendUrlSuffix(Mockito.anyString());
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestUrlEndingWithoutSlashClient() {
-        String urlWithSuffix = apacheCloudStackClient.adjustUrlIfNeeded("https://cloud.domain.com/");
-        Assert.assertEquals(cloudStackUrl, urlWithSuffix);
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestUrlEndingWithoutSlashAndClient() {
-        String urlWithSuffix = apacheCloudStackClient.adjustUrlIfNeeded("https://cloud.domain.com");
-        Assert.assertEquals(cloudStackUrl, urlWithSuffix);
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestUrlEndingWithSlashClientWithoutLastSlash() {
-        String urlWithSuffix = apacheCloudStackClient.adjustUrlIfNeeded("https://cloud.domain.com/client");
-        Assert.assertEquals(cloudStackUrl, urlWithSuffix);
-    }
-
-    @Test
-    public void adjustUrlIfNeededTestUrlEndingWithSlashClientWithtLastSlash() {
-        String urlWithSuffix = apacheCloudStackClient.adjustUrlIfNeeded("https://cloud.domain.com/client/");
-        Assert.assertEquals(cloudStackUrl + "/", urlWithSuffix);
-    }
-
-    @Test
-    public void appendUrlSuffixTestEndingWithSlash(){
-        String urlWithSuffix = apacheCloudStackClient.appendUrlSuffix("https://cloud.domain.com/");
-        Assert.assertEquals(cloudStackUrl, urlWithSuffix);
-    }
-
-    @Test
-    public void appendUrlSuffixTestEndingWithoutSlash() {
-        String urlWithSuffix = apacheCloudStackClient.appendUrlSuffix("https://cloud.domain.com");
-        Assert.assertEquals(cloudStackUrl, urlWithSuffix);
     }
 
     @Test
@@ -233,7 +179,7 @@ public class ApacheCloudStackClientTest {
         Mockito.doReturn(signatureValue).when(apacheCloudStackClient).createSignature(Mockito.eq(queryString));
 
         String urlRequestReturned = apacheCloudStackClient.createApacheCloudStackApiUrlRequest(apacheCloudStackRequestMock, true);
-        Assert.assertEquals(cloudStackUrl + "/api?" + queryString + "&signature=" + signatureValue, urlRequestReturned);
+        Assert.assertEquals(cloudStackUrl + "?" + queryString + "&signature=" + signatureValue, urlRequestReturned);
 
         InOrder inOrder = Mockito.inOrder(apacheCloudStackClient);
         inOrder.verify(apacheCloudStackClient).createCommandString(Mockito.eq(apacheCloudStackRequestMock));
@@ -249,7 +195,7 @@ public class ApacheCloudStackClientTest {
         Mockito.doReturn(queryString).when(apacheCloudStackClient).createCommandString(Mockito.eq(apacheCloudStackRequestMock));
 
         String urlRequestReturned = apacheCloudStackClient.createApacheCloudStackApiUrlRequest(apacheCloudStackRequestMock, false);
-        Assert.assertEquals(cloudStackUrl + "/api?" + queryString, urlRequestReturned);
+        Assert.assertEquals(cloudStackUrl + "?" + queryString, urlRequestReturned);
 
         InOrder inOrder = Mockito.inOrder(apacheCloudStackClient);
         inOrder.verify(apacheCloudStackClient).createCommandString(Mockito.eq(apacheCloudStackRequestMock));
@@ -544,7 +490,7 @@ public class ApacheCloudStackClientTest {
     public void createHttpPostTest() throws MalformedURLException {
         HttpPost httpPost = apacheCloudStackClient.createHttpPost();
 
-        Assert.assertEquals(cloudStackUrl + "/api", httpPost.getURI().toURL().toString());
+        Assert.assertEquals(cloudStackUrl, httpPost.getURI().toURL().toString());
         Assert.assertEquals("application/x-www-form-urlencoded", httpPost.getFirstHeader("Content-Type").getValue());
     }
 


### PR DESCRIPTION
This removes assumptions around the CloudStack API urls to have /client/api, or
/api suffix. By removing this, it will be responsibility of the client-library
user to ensure that the passed URL while creating the ApacheCloudStackClient
instance is the API url.

In several production environments, the API url may be behind a reverse-proxy.
This change addresses such environments.

Ping @rafaelweingartner - please review and advise any other changes.